### PR TITLE
Get rid of redundant `Client` interface

### DIFF
--- a/services/client.go
+++ b/services/client.go
@@ -7,20 +7,6 @@ import (
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodes"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/keypairs"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/servergroups"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/eips"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 )
 
 const (
@@ -29,83 +15,8 @@ const (
 	defaultEndpointType = golangsdk.AvailabilityPublic
 )
 
-type Client interface {
-	Authenticate() error
-	NewServiceClient(service string) (*golangsdk.ServiceClient, error)
-	Token() (string, error)
-	InitVPC() error
-	CreateVPC(vpcName string) (*vpcs.Vpc, error)
-	GetVPCDetails(vpcID string) (*vpcs.Vpc, error)
-	FindVPC(vpcName string) (string, error)
-	WaitForVPCStatus(vpcID string, status string) error
-	DeleteVPC(vpcID string) error
-	CreateSubnet(vpcID, subnetName string) (*subnets.Subnet, error)
-	FindSubnet(vpcID, subnetName string) (string, error)
-	GetSubnetStatus(subnetID string) (*subnets.Subnet, error)
-	WaitForSubnetStatus(subnetID string, status string) error
-	DeleteSubnet(vpcID string, subnetID string) error
-	GetEIPStatus(eipID string) (string, error)
-	CreateEIP(opts *ElasticIPOpts) (*eips.PublicIp, error)
-	WaitForEIPActive(eipID string) error
-	InitCompute() error
-	CreateInstance(opts *ExtendedServerOpts) (*servers.Server, error)
-	StartInstance(instanceID string) error
-	StopInstance(instanceID string) error
-	RestartInstance(instanceID string) error
-	DeleteInstance(instanceID string) error
-	FindInstance(name string) (string, error)
-	GetInstanceStatus(instanceID string) (*servers.Server, error)
-	WaitForInstanceStatus(instanceID string, status string) error
-	InstanceBindToIP(instanceID, ip string) (bool, error)
-	GetPublicKey(keyPairName string) ([]byte, error)
-	CreateKeyPair(name string, publicKey string) (*keypairs.KeyPair, error)
-	FindKeyPair(name string) (string, error)
-	DeleteKeyPair(name string) error
-	FindFlavor(flavorName string) (string, error)
-	FindImage(imageName string) (string, error)
-	CreateSecurityGroup(securityGroupName string, ports ...PortRange) (*secgroups.SecurityGroup, error)
-	FindSecurityGroups(secGroups []string) ([]string, error)
-	DeleteSecurityGroup(securityGroupID string) error
-	WaitForGroupDeleted(securityGroupID string) error
-	BindFloatingIP(floatingIP, instanceID string) error
-	UnbindFloatingIP(floatingIP, instanceID string) error
-	FindFloatingIP(floatingIP string) (addressID string, err error)
-	DeleteFloatingIP(floatingIP string) error
-	FindServerGroup(groupName string) (result string, err error)
-	AddTags(instanceID string, serverTags []string) error
-	CreateServerGroup(opts *servergroups.CreateOpts) (*servergroups.ServerGroup, error)
-	DeleteServerGroup(groupID string) error
-	InitCCE() error
-	CreateCluster(opts *CreateClusterOpts) (*clusters.Clusters, error)
-	GetCluster(clusterID string) (*clusters.Clusters, error)
-	GetClusterCertificate(clusterID string) (*clusters.Certificate, error)
-	UpdateCluster(clusterID string, opts *clusters.UpdateSpec) error
-	DeleteCluster(clusterID string) error
-	CreateNodes(opts *CreateNodesOpts, count int) ([]string, error)
-	GetNodesStatus(clusterID string, nodeIDs []string) ([]*nodes.Status, error)
-	DeleteNodes(clusterID string, nodeIDs []string) error
-	InitNetworkV2() error
-	CreateLoadBalancer(opts *loadbalancers.CreateOpts) (*loadbalancers.LoadBalancer, error)
-	GetLoadBalancerDetails(id string) (*loadbalancers.LoadBalancer, error)
-	DeleteLoadBalancer(id string) error
-	BindFloatingIPToPort(floatingIP, portID string) error
-	CreateLBListener(opts *listeners.CreateOpts) (*listeners.Listener, error)
-	DeleteLBListener(id string) error
-	CreateLBPool(opts *pools.CreateOpts) (*pools.Pool, error)
-	DeleteLBPool(id string) error
-	CreateLBMember(poolID string, opts *pools.CreateMemberOpts) (*pools.Member, error)
-	GetLBMemberStatus(poolID, memberID string) (*pools.Member, error)
-	DeleteLBMember(poolID, memberID string) error
-	CreateLBMonitor(opts *monitors.CreateOpts) (*monitors.Monitor, error)
-	DeleteLBMonitor(id string) error
-	InitECS() error
-	CreateECSInstance(opts cloudservers.CreateOptsBuilder, timeoutSeconds int) (string, error)
-	GetECSStatus(instanceID string) (*cloudservers.CloudServer, error)
-	DeleteECSInstance(instanceID string) error
-}
-
-// client contains service clients
-type client struct {
+// Client contains service clients
+type Client struct {
 	Provider *golangsdk.ProviderClient
 
 	ECS       *golangsdk.ServiceClient
@@ -117,23 +28,23 @@ type client struct {
 	cloud *openstack.Cloud
 }
 
-func NewCloudClient(cloud *openstack.Cloud) Client {
-	return &client{cloud: cloud}
+func NewCloudClient(cloud *openstack.Cloud) *Client {
+	return &Client{cloud: cloud}
 }
 
-func NewClient(prefix string) (Client, error) {
+func NewClient(prefix string) (*Client, error) {
 	env := openstack.NewEnv(prefix)
 	cloud, err := env.Cloud()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load cloud config: %s", err)
 	}
-	return &client{cloud: cloud}, nil
+	return &Client{cloud: cloud}, nil
 }
 
 var userAgent = fmt.Sprintf("otc-crutch-house/v0.1")
 
-// AuthenticateWithToken authenticate client in the cloud with token (either directly or via username/password)
-func (c *client) Authenticate() error {
+// Authenticate authenticate client in the cloud with token (either directly or via username/password)
+func (c *Client) Authenticate() error {
 	if c.Provider != nil && c.Provider.Token() != "" {
 		return nil
 	}
@@ -146,7 +57,7 @@ func (c *client) Authenticate() error {
 	return nil
 }
 
-func (c *client) Token() (string, error) {
+func (c *Client) Token() (string, error) {
 	if c.Provider == nil || c.Provider.Token() == "" {
 		if err := c.Authenticate(); err != nil {
 			return "", err
@@ -169,7 +80,7 @@ func getAvailability(endpointType string) golangsdk.Availability {
 }
 
 // NewServiceClient is a convenience function to get a new service client.
-func (c *client) NewServiceClient(service string) (*golangsdk.ServiceClient, error) {
+func (c *Client) NewServiceClient(service string) (*golangsdk.ServiceClient, error) {
 	if err := c.Authenticate(); err != nil {
 		return nil, err
 	}

--- a/services/client_test.go
+++ b/services/client_test.go
@@ -46,7 +46,7 @@ func cleanUpEnvVars(vars []string) {
 	}
 }
 
-func authClient(t *testing.T) Client {
+func authClient(t *testing.T) *Client {
 	pref := "OS_"
 
 	client, err := NewClient(pref)

--- a/services/compute.go
+++ b/services/compute.go
@@ -26,7 +26,7 @@ const (
 )
 
 // InitCompute initializes Compute v2 service
-func (c *client) InitCompute() error {
+func (c *Client) InitCompute() error {
 	if c.ComputeV2 != nil {
 		return nil
 	}
@@ -66,7 +66,7 @@ type ExtendedServerOpts struct {
 }
 
 // CreateInstance creates new ECS
-func (c *client) CreateInstance(opts *ExtendedServerOpts) (*servers.Server, error) {
+func (c *Client) CreateInstance(opts *ExtendedServerOpts) (*servers.Server, error) {
 
 	var createOpts servers.CreateOptsBuilder = &servers.CreateOpts{
 		Name:             opts.Name,
@@ -108,28 +108,28 @@ func (c *client) CreateInstance(opts *ExtendedServerOpts) (*servers.Server, erro
 }
 
 // StartInstance starts existing ECS instance
-func (c *client) StartInstance(instanceID string) error {
+func (c *Client) StartInstance(instanceID string) error {
 	return startstop.Start(c.ComputeV2, instanceID).Err
 }
 
 // StopInstance stops existing ECS instance
-func (c *client) StopInstance(instanceID string) error {
+func (c *Client) StopInstance(instanceID string) error {
 	return startstop.Stop(c.ComputeV2, instanceID).Err
 }
 
 // RestartInstance restarts ECS instance
-func (c *client) RestartInstance(instanceID string) error {
+func (c *Client) RestartInstance(instanceID string) error {
 	opts := &servers.RebootOpts{Type: servers.SoftReboot}
 	return servers.Reboot(c.ComputeV2, instanceID, opts).Err
 }
 
 // DeleteInstance removes existing ECS instance
-func (c *client) DeleteInstance(instanceID string) error {
+func (c *Client) DeleteInstance(instanceID string) error {
 	return servers.Delete(c.ComputeV2, instanceID).Err
 }
 
 // FindInstance returns instance ID by instance Name
-func (c *client) FindInstance(name string) (string, error) {
+func (c *Client) FindInstance(name string) (string, error) {
 	listOpts := servers.ListOpts{Name: name}
 	pager := servers.List(c.ComputeV2, listOpts)
 	serverID := ""
@@ -151,17 +151,17 @@ func (c *client) FindInstance(name string) (string, error) {
 }
 
 // GetInstanceStatus returns instance details by instance ID
-func (c *client) GetInstanceStatus(instanceID string) (*servers.Server, error) {
+func (c *Client) GetInstanceStatus(instanceID string) (*servers.Server, error) {
 	return servers.Get(c.ComputeV2, instanceID).Extract()
 }
 
 // WaitForInstanceStatus waits for instance to be in given status
-func (c *client) WaitForInstanceStatus(instanceID string, status string) error {
+func (c *Client) WaitForInstanceStatus(instanceID string, status string) error {
 	return servers.WaitForStatus(c.ComputeV2, instanceID, status, 300)
 }
 
 // InstanceBindToIP checks if instance has IP bind
-func (c *client) InstanceBindToIP(instanceID string, ip string) (bool, error) {
+func (c *Client) InstanceBindToIP(instanceID string, ip string) (bool, error) {
 	instanceDetails, err := c.GetInstanceStatus(instanceID)
 	if err != nil {
 		return false, err
@@ -178,7 +178,7 @@ func (c *client) InstanceBindToIP(instanceID string, ip string) (bool, error) {
 }
 
 // GetPublicKey returns public key data from keypair
-func (c *client) GetPublicKey(keyPairName string) ([]byte, error) {
+func (c *Client) GetPublicKey(keyPairName string) ([]byte, error) {
 	keyPair, err := keypairs.Get(c.ComputeV2, keyPairName).Extract()
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (c *client) GetPublicKey(keyPairName string) ([]byte, error) {
 }
 
 // CreateKeyPair creates new key pair from given public key string
-func (c *client) CreateKeyPair(name string, publicKey string) (*keypairs.KeyPair, error) {
+func (c *Client) CreateKeyPair(name string, publicKey string) (*keypairs.KeyPair, error) {
 	opts := keypairs.CreateOpts{
 		Name:      name,
 		PublicKey: publicKey,
@@ -200,7 +200,7 @@ func (c *client) CreateKeyPair(name string, publicKey string) (*keypairs.KeyPair
 }
 
 // FindKeyPair searches for key pair and returns public key
-func (c *client) FindKeyPair(name string) (string, error) {
+func (c *Client) FindKeyPair(name string) (string, error) {
 	pager := keypairs.List(c.ComputeV2)
 	publicKey := ""
 	err := pager.EachPage(func(page pagination.Page) (b bool, err error) {
@@ -223,12 +223,12 @@ func (c *client) FindKeyPair(name string) (string, error) {
 }
 
 // DeleteKeyPair removes existing key pair
-func (c *client) DeleteKeyPair(name string) error {
+func (c *Client) DeleteKeyPair(name string) error {
 	return keypairs.Delete(c.ComputeV2, name).Err
 }
 
 // FindFlavor resolves `Flavor ID` for given `Flavor Name`
-func (c *client) FindFlavor(flavorName string) (string, error) {
+func (c *Client) FindFlavor(flavorName string) (string, error) {
 	pagedFlavors := flavors.ListDetail(c.ComputeV2, nil)
 	flavorID := ""
 	err := pagedFlavors.EachPage(func(page pagination.Page) (b bool, err error) {
@@ -251,7 +251,7 @@ func (c *client) FindFlavor(flavorName string) (string, error) {
 }
 
 // FindImage resolve image ID by given image Name
-func (c *client) FindImage(imageName string) (string, error) {
+func (c *Client) FindImage(imageName string) (string, error) {
 	opts := images.ListOpts{Name: imageName}
 	pager := images.List(c.ComputeV2, opts)
 	imageID := ""
@@ -279,7 +279,7 @@ const (
 	tcpProtocol = "TCP"
 )
 
-func (c *client) addInboundRule(secGroupID string, fromPort int, toPort int) error {
+func (c *Client) addInboundRule(secGroupID string, fromPort int, toPort int) error {
 
 	ruleOpts := secgroups.CreateRuleOpts{
 		ParentGroupID: secGroupID,
@@ -298,7 +298,7 @@ type PortRange struct {
 }
 
 // CreateSecurityGroup creates new sec group and returns group ID
-func (c *client) CreateSecurityGroup(securityGroupName string, ports ...PortRange) (*secgroups.SecurityGroup, error) {
+func (c *Client) CreateSecurityGroup(securityGroupName string, ports ...PortRange) (*secgroups.SecurityGroup, error) {
 	opts := secgroups.CreateOpts{
 		Name:        securityGroupName,
 		Description: "Automatically created by docker-machine for OTC",
@@ -346,7 +346,7 @@ func findSGInPagerByNameOrID(secGroups []string, pager pagination.Pager) ([]stri
 }
 
 // FindSecurityGroups get slice of security group IDs from given security group names
-func (c *client) FindSecurityGroups(secGroups []string) ([]string, error) {
+func (c *Client) FindSecurityGroups(secGroups []string) ([]string, error) {
 	pager := secgroups.List(c.ComputeV2)
 	secGroupIDs, missing, err := findSGInPagerByNameOrID(secGroups, pager)
 	if err != nil {
@@ -360,12 +360,12 @@ func (c *client) FindSecurityGroups(secGroups []string) ([]string, error) {
 }
 
 // DeleteSecurityGroup deletes managed security group
-func (c *client) DeleteSecurityGroup(securityGroupID string) error {
+func (c *Client) DeleteSecurityGroup(securityGroupID string) error {
 	return secgroups.Delete(c.ComputeV2, securityGroupID).Err
 }
 
 // WaitForGroupDeleted polls sec group until it returns 404
-func (c *client) WaitForGroupDeleted(securityGroupID string) error {
+func (c *Client) WaitForGroupDeleted(securityGroupID string) error {
 	return golangsdk.WaitFor(60, func() (b bool, e error) {
 		err := secgroups.Get(c.ComputeV2, securityGroupID).Err
 		if err == nil {
@@ -381,19 +381,19 @@ func (c *client) WaitForGroupDeleted(securityGroupID string) error {
 }
 
 // BindFloatingIP binds floating IP to instance
-func (c *client) BindFloatingIP(floatingIP, instanceID string) error {
+func (c *Client) BindFloatingIP(floatingIP, instanceID string) error {
 	opts := floatingips.AssociateOpts{FloatingIP: floatingIP}
 	return floatingips.AssociateInstance(c.ComputeV2, instanceID, opts).Err
 }
 
 // UnbindFloatingIP unbinds floating IP to instance
-func (c *client) UnbindFloatingIP(floatingIP, instanceID string) error {
+func (c *Client) UnbindFloatingIP(floatingIP, instanceID string) error {
 	opts := floatingips.DisassociateOpts{FloatingIP: floatingIP}
 	return floatingips.DisassociateInstance(c.ComputeV2, instanceID, opts).Err
 }
 
 // FindFloatingIP finds given floating IP and returns ID
-func (c *client) FindFloatingIP(floatingIP string) (addressID string, err error) {
+func (c *Client) FindFloatingIP(floatingIP string) (addressID string, err error) {
 	pager := floatingips.List(c.ComputeV2)
 	addressID = ""
 	err = pager.EachPage(func(page pagination.Page) (b bool, err error) {
@@ -413,7 +413,7 @@ func (c *client) FindFloatingIP(floatingIP string) (addressID string, err error)
 }
 
 // DeleteFloatingIP releases floating IP
-func (c *client) DeleteFloatingIP(floatingIP string) error {
+func (c *Client) DeleteFloatingIP(floatingIP string) error {
 	address, err := c.FindFloatingIP(floatingIP)
 	if err != nil {
 		return err
@@ -421,7 +421,7 @@ func (c *client) DeleteFloatingIP(floatingIP string) error {
 	return floatingips.Delete(c.ComputeV2, address).Err
 }
 
-func (c *client) FindServerGroup(groupName string) (result string, err error) {
+func (c *Client) FindServerGroup(groupName string) (result string, err error) {
 	pager := servergroups.List(c.ComputeV2)
 	result = ""
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
@@ -440,15 +440,15 @@ func (c *client) FindServerGroup(groupName string) (result string, err error) {
 	return
 }
 
-func (c *client) AddTags(instanceID string, serverTags []string) error {
+func (c *Client) AddTags(instanceID string, serverTags []string) error {
 	opts := tags.CreateOpts{Tags: serverTags}
 	return tags.Create(c.ComputeV2, instanceID, opts).Err
 }
 
-func (c *client) CreateServerGroup(opts *servergroups.CreateOpts) (*servergroups.ServerGroup, error) {
+func (c *Client) CreateServerGroup(opts *servergroups.CreateOpts) (*servergroups.ServerGroup, error) {
 	return servergroups.Create(c.ComputeV2, opts).Extract()
 }
 
-func (c *client) DeleteServerGroup(id string) error {
+func (c *Client) DeleteServerGroup(id string) error {
 	return servergroups.Delete(c.ComputeV2, id).Err
 }

--- a/services/compute_test.go
+++ b/services/compute_test.go
@@ -86,7 +86,7 @@ func cleanupResources(t *testing.T) {
 
 }
 
-func computeClient(t *testing.T) Client {
+func computeClient(t *testing.T) *Client {
 	client := authClient(t)
 	require.NoError(t, client.InitCompute())
 	return client
@@ -156,7 +156,7 @@ func TestClient_CreateFloatingIP(t *testing.T) {
 	assert.Empty(t, addrID)
 }
 
-func waitForInstanceIPBind(c Client, instanceID string, ip string, bind bool) error {
+func waitForInstanceIPBind(c *Client, instanceID string, ip string, bind bool) error {
 	return golangsdk.WaitFor(300, func() (b bool, err error) {
 		assigned, err := c.InstanceBindToIP(instanceID, ip)
 		if err != nil {
@@ -169,14 +169,14 @@ func waitForInstanceIPBind(c Client, instanceID string, ip string, bind bool) er
 	})
 }
 
-func createServerGroup(client Client) (group *servergroups.ServerGroup, err error) {
+func createServerGroup(client *Client) (group *servergroups.ServerGroup, err error) {
 	return client.CreateServerGroup(&servergroups.CreateOpts{
 		Name:     "test-group",
 		Policies: []string{"anti-affinity"},
 	})
 }
 
-func deleteServerGroup(cl Client, id string) {
+func deleteServerGroup(cl *Client, id string) {
 	_ = cl.DeleteServerGroup(id)
 }
 

--- a/services/containers_test.go
+++ b/services/containers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opentelekomcloud-infra/crutch-house/utils"
 )
 
-func initCCE(t *testing.T, client Client) {
+func initCCE(t *testing.T, client *Client) {
 	require.NoError(t, client.InitCCE())
 }
 

--- a/services/ecs.go
+++ b/services/ecs.go
@@ -11,7 +11,7 @@ const (
 )
 
 // InitECS initializes Compute v1 (ECS) service
-func (c *client) InitECS() error {
+func (c *Client) InitECS() error {
 	if c.ECS != nil {
 		return nil
 	}
@@ -24,7 +24,7 @@ func (c *client) InitECS() error {
 }
 
 // CreateECSInstance - create new ECS instance
-func (c *client) CreateECSInstance(opts cloudservers.CreateOptsBuilder, timeoutSeconds int) (string, error) {
+func (c *Client) CreateECSInstance(opts cloudservers.CreateOptsBuilder, timeoutSeconds int) (string, error) {
 	if err := c.InitECS(); err != nil {
 		return "", err
 	}
@@ -46,14 +46,14 @@ func (c *client) CreateECSInstance(opts cloudservers.CreateOptsBuilder, timeoutS
 	return id, nil
 }
 
-func (c *client) GetECSStatus(instanceID string) (*cloudservers.CloudServer, error) {
+func (c *Client) GetECSStatus(instanceID string) (*cloudservers.CloudServer, error) {
 	if err := c.InitECS(); err != nil {
 		return nil, err
 	}
 	return cloudservers.Get(c.ECS, instanceID).Extract()
 }
 
-func (c *client) DeleteECSInstance(instanceID string) error {
+func (c *Client) DeleteECSInstance(instanceID string) error {
 	if err := c.InitECS(); err != nil {
 		return err
 	}

--- a/services/ecs_test.go
+++ b/services/ecs_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ecsClient(t *testing.T) Client {
+func ecsClient(t *testing.T) *Client {
 	client := authClient(t)
 	require.NoError(t, client.InitECS())
 	return client

--- a/services/networking_v2.go
+++ b/services/networking_v2.go
@@ -14,7 +14,7 @@ import (
 const LBStateActive = "ACTIVE"
 
 // InitNetworkV2 initializes OpenStack Neutron client
-func (c *client) InitNetworkV2() error {
+func (c *Client) InitNetworkV2() error {
 	if c.NetworkV2 != nil {
 		return nil
 	}
@@ -27,7 +27,7 @@ func (c *client) InitNetworkV2() error {
 }
 
 // CreateLoadBalancer creating new ELBv2
-func (c *client) CreateLoadBalancer(opts *loadbalancers.CreateOpts) (*loadbalancers.LoadBalancer, error) {
+func (c *Client) CreateLoadBalancer(opts *loadbalancers.CreateOpts) (*loadbalancers.LoadBalancer, error) {
 	lb, err := loadbalancers.Create(c.NetworkV2, opts).Extract()
 	if err != nil {
 		return nil, err
@@ -41,11 +41,11 @@ func (c *client) CreateLoadBalancer(opts *loadbalancers.CreateOpts) (*loadbalanc
 }
 
 // GetLoadBalancerDetails fetches load balancer data
-func (c *client) GetLoadBalancerDetails(id string) (*loadbalancers.LoadBalancer, error) {
+func (c *Client) GetLoadBalancerDetails(id string) (*loadbalancers.LoadBalancer, error) {
 	return loadbalancers.Get(c.NetworkV2, id).Extract()
 }
 
-func (c *client) waitForLBActive(loadBalancerID string) error {
+func (c *Client) waitForLBActive(loadBalancerID string) error {
 	return golangsdk.WaitFor(60, func() (bool, error) {
 		lb, err := c.GetLoadBalancerDetails(loadBalancerID)
 		if err != nil {
@@ -58,7 +58,7 @@ func (c *client) waitForLBActive(loadBalancerID string) error {
 	})
 }
 
-func (c *client) waitForLBDeleted(loadBalancerID string) error {
+func (c *Client) waitForLBDeleted(loadBalancerID string) error {
 	return golangsdk.WaitFor(60, func() (bool, error) {
 		_, err := c.GetLoadBalancerDetails(loadBalancerID)
 		if err == nil {
@@ -74,7 +74,7 @@ func (c *client) waitForLBDeleted(loadBalancerID string) error {
 }
 
 // DeleteLoadBalancer removes existing load balancer
-func (c *client) DeleteLoadBalancer(id string) error {
+func (c *Client) DeleteLoadBalancer(id string) error {
 	if err := loadbalancers.Delete(c.NetworkV2, id).Err; err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (c *client) DeleteLoadBalancer(id string) error {
 }
 
 // BindFloatingIPToPort binds floating IP to networking port
-func (c *client) BindFloatingIPToPort(floatingIP, portID string) error {
+func (c *Client) BindFloatingIPToPort(floatingIP, portID string) error {
 	page, err := floatingips.List(c.NetworkV2, floatingips.ListOpts{
 		FloatingIP: floatingIP,
 	}).AllPages()
@@ -100,36 +100,36 @@ func (c *client) BindFloatingIPToPort(floatingIP, portID string) error {
 	return floatingips.Update(c.NetworkV2, ids[0].ID, opts).Err
 }
 
-func (c *client) CreateLBListener(opts *listeners.CreateOpts) (*listeners.Listener, error) {
+func (c *Client) CreateLBListener(opts *listeners.CreateOpts) (*listeners.Listener, error) {
 	return listeners.Create(c.NetworkV2, *opts).Extract()
 }
 
-func (c *client) DeleteLBListener(id string) error {
+func (c *Client) DeleteLBListener(id string) error {
 	return listeners.Delete(c.NetworkV2, id).Err
 }
 
-func (c *client) CreateLBPool(opts *pools.CreateOpts) (*pools.Pool, error) {
+func (c *Client) CreateLBPool(opts *pools.CreateOpts) (*pools.Pool, error) {
 	return pools.Create(c.NetworkV2, opts).Extract()
 }
 
-func (c *client) DeleteLBPool(id string) error {
+func (c *Client) DeleteLBPool(id string) error {
 	return pools.Delete(c.NetworkV2, id).Err
 }
 
-func (c *client) CreateLBMember(poolID string, opts *pools.CreateMemberOpts) (*pools.Member, error) {
+func (c *Client) CreateLBMember(poolID string, opts *pools.CreateMemberOpts) (*pools.Member, error) {
 	return pools.CreateMember(c.NetworkV2, poolID, *opts).Extract()
 }
 
-func (c *client) GetLBMemberStatus(poolID, memberID string) (*pools.Member, error) {
+func (c *Client) GetLBMemberStatus(poolID, memberID string) (*pools.Member, error) {
 	return pools.GetMember(c.NetworkV2, poolID, memberID).Extract()
 }
 
-func (c *client) DeleteLBMember(poolID, memberID string) error {
+func (c *Client) DeleteLBMember(poolID, memberID string) error {
 	return pools.DeleteMember(c.NetworkV2, poolID, memberID).Err
 }
 
 // as it's done in terraform provider
-func (c *client) waitForLBV2viaPool(id string) error {
+func (c *Client) waitForLBV2viaPool(id string) error {
 	pool, err := pools.Get(c.NetworkV2, id).Extract()
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func (c *client) waitForLBV2viaPool(id string) error {
 	return fmt.Errorf("no Load Balancer on pool %s", id)
 }
 
-func (c *client) CreateLBMonitor(opts *monitors.CreateOpts) (*monitors.Monitor, error) {
+func (c *Client) CreateLBMonitor(opts *monitors.CreateOpts) (*monitors.Monitor, error) {
 	if err := c.waitForLBV2viaPool(opts.PoolID); err != nil {
 		return nil, err
 	}
@@ -168,6 +168,6 @@ func (c *client) CreateLBMonitor(opts *monitors.CreateOpts) (*monitors.Monitor, 
 	return monitor, nil
 }
 
-func (c *client) DeleteLBMonitor(id string) error {
+func (c *Client) DeleteLBMonitor(id string) error {
 	return monitors.Delete(c.NetworkV2, id).Err
 }

--- a/services/networking_v2_test.go
+++ b/services/networking_v2_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/getlantern/deepcopy"
 )
 
-func initClients(t *testing.T, client Client) {
+func initClients(t *testing.T, client *Client) {
 	require.NoError(t, client.InitVPC())
 	require.NoError(t, client.InitNetworkV2())
 	require.NoError(t, client.InitCompute())
@@ -28,7 +28,7 @@ func initClients(t *testing.T, client Client) {
 
 const protocol = "HTTP"
 
-func createNodes(cl Client, opts *ExtendedServerOpts, netCIDR string, count int) (nodes []*servers.Server, addresses []string, err error) {
+func createNodes(cl *Client, opts *ExtendedServerOpts, netCIDR string, count int) (nodes []*servers.Server, addresses []string, err error) {
 	nodeChan := make(chan *servers.Server, count)
 	errChan := make(chan error, count)
 
@@ -71,7 +71,7 @@ func createNodes(cl Client, opts *ExtendedServerOpts, netCIDR string, count int)
 	return nodes, addresses, mErr.ErrorOrNil()
 }
 
-func deleteNodes(cl Client, nodes []*servers.Server) error {
+func deleteNodes(cl *Client, nodes []*servers.Server) error {
 	errChan := make(chan error, len(nodes))
 
 	for _, node := range nodes {
@@ -109,7 +109,7 @@ func deleteNodes(cl Client, nodes []*servers.Server) error {
 }
 
 // in-place update of servers status
-func updateNodesStatus(cl Client, nodes []*servers.Server) error {
+func updateNodesStatus(cl *Client, nodes []*servers.Server) error {
 	for i, node := range nodes {
 		nod, err := cl.GetInstanceStatus(node.ID)
 		if err != nil {
@@ -120,7 +120,7 @@ func updateNodesStatus(cl Client, nodes []*servers.Server) error {
 	return nil
 }
 
-func createMembers(cl Client, poolID string, opts *pools.CreateMemberOpts, nodes []*servers.Server, addresses []string) ([]*pools.Member, error) {
+func createMembers(cl *Client, poolID string, opts *pools.CreateMemberOpts, nodes []*servers.Server, addresses []string) ([]*pools.Member, error) {
 	memes := make([]*pools.Member, len(nodes))
 	errChan := make(chan error, len(nodes))
 	memChan := make(chan *pools.Member, len(nodes))
@@ -146,7 +146,7 @@ func createMembers(cl Client, poolID string, opts *pools.CreateMemberOpts, nodes
 	return memes, err.ErrorOrNil()
 }
 
-func deleteMembers(cl Client, poolID string, memes []*pools.Member) error {
+func deleteMembers(cl *Client, poolID string, memes []*pools.Member) error {
 	errChan := make(chan error, len(memes))
 	for _, mem := range memes {
 		go func(id string) {

--- a/services/vpc.go
+++ b/services/vpc.go
@@ -23,7 +23,7 @@ const (
 var defaultDNS = []string{primaryDNS, secondaryDNS}
 
 // InitVPC initializes VPC v1 service
-func (c *client) InitVPC() error {
+func (c *Client) InitVPC() error {
 	if c.VPC != nil {
 		return nil
 	}
@@ -36,7 +36,7 @@ func (c *client) InitVPC() error {
 }
 
 // CreateVPC creates new VPC by d.VpcName
-func (c *client) CreateVPC(vpcName string) (*vpcs.Vpc, error) {
+func (c *Client) CreateVPC(vpcName string) (*vpcs.Vpc, error) {
 	return vpcs.Create(c.VPC, vpcs.CreateOpts{
 		Name: vpcName,
 		CIDR: vpcCIDR,
@@ -44,12 +44,12 @@ func (c *client) CreateVPC(vpcName string) (*vpcs.Vpc, error) {
 }
 
 // GetVPCDetails returns details of VPC
-func (c *client) GetVPCDetails(vpcID string) (*vpcs.Vpc, error) {
+func (c *Client) GetVPCDetails(vpcID string) (*vpcs.Vpc, error) {
 	return vpcs.Get(c.VPC, vpcID).Extract()
 }
 
 // FindVPC find VPC in list by its name and return VPC ID
-func (c *client) FindVPC(vpcName string) (string, error) {
+func (c *Client) FindVPC(vpcName string) (string, error) {
 	opts := vpcs.ListOpts{
 		Name: vpcName,
 	}
@@ -67,7 +67,7 @@ func (c *client) FindVPC(vpcName string) (string, error) {
 }
 
 // WaitForVPCStatus waits until VPC is in given status
-func (c *client) WaitForVPCStatus(vpcID, status string) error {
+func (c *Client) WaitForVPCStatus(vpcID, status string) error {
 	return utils.WaitForSpecificOrError(func() (b bool, err error) {
 		cur, err := c.GetVPCDetails(vpcID)
 		if err != nil {
@@ -84,12 +84,12 @@ func (c *client) WaitForVPCStatus(vpcID, status string) error {
 }
 
 // DeleteVPC removes existing VPC
-func (c *client) DeleteVPC(vpcID string) error {
+func (c *Client) DeleteVPC(vpcID string) error {
 	return vpcs.Delete(c.VPC, vpcID).Err
 }
 
 // CreateSubnet creates new Subnet and set Driver.SubnetID
-func (c *client) CreateSubnet(vpcID string, subnetName string) (*subnets.Subnet, error) {
+func (c *Client) CreateSubnet(vpcID string, subnetName string) (*subnets.Subnet, error) {
 	return subnets.Create(c.VPC, subnets.CreateOpts{
 		VPC_ID:     vpcID,
 		Name:       subnetName,
@@ -102,7 +102,7 @@ func (c *client) CreateSubnet(vpcID string, subnetName string) (*subnets.Subnet,
 }
 
 // FindSubnet find subnet by name in given VPC and return ID
-func (c *client) FindSubnet(vpcID string, subnetName string) (string, error) {
+func (c *Client) FindSubnet(vpcID string, subnetName string) (string, error) {
 	subnetList, err := subnets.List(c.VPC, subnets.ListOpts{
 		Name:   subnetName,
 		VPC_ID: vpcID,
@@ -121,12 +121,12 @@ func (c *client) FindSubnet(vpcID string, subnetName string) (string, error) {
 }
 
 // GetSubnetStatus returns details of subnet by ID
-func (c *client) GetSubnetStatus(subnetID string) (*subnets.Subnet, error) {
+func (c *Client) GetSubnetStatus(subnetID string) (*subnets.Subnet, error) {
 	return subnets.Get(c.VPC, subnetID).Extract()
 }
 
 // WaitForSubnetStatus waits for subnet to be in given status
-func (c *client) WaitForSubnetStatus(subnetID string, status string) error {
+func (c *Client) WaitForSubnetStatus(subnetID string, status string) error {
 	return utils.WaitForSpecificOrError(func() (b bool, err error) {
 		curStatus, err := c.GetSubnetStatus(subnetID)
 		if err != nil {
@@ -143,7 +143,7 @@ func (c *client) WaitForSubnetStatus(subnetID string, status string) error {
 }
 
 // DeleteSubnet removes subnet from VPC
-func (c *client) DeleteSubnet(vpcID string, subnetID string) error {
+func (c *Client) DeleteSubnet(vpcID string, subnetID string) error {
 	return subnets.Delete(c.VPC, vpcID, subnetID).Err
 }
 
@@ -153,7 +153,7 @@ type ElasticIPOpts struct {
 	BandwidthType string
 }
 
-func (c *client) GetEIPStatus(eipID string) (string, error) {
+func (c *Client) GetEIPStatus(eipID string) (string, error) {
 	eip, err := eips.Get(c.VPC, eipID).Extract()
 	if err != nil {
 		return "", err
@@ -161,7 +161,7 @@ func (c *client) GetEIPStatus(eipID string) (string, error) {
 	return eip.Status, err
 }
 
-func (c *client) CreateEIP(opts *ElasticIPOpts) (*eips.PublicIp, error) {
+func (c *Client) CreateEIP(opts *ElasticIPOpts) (*eips.PublicIp, error) {
 	if opts.IPType == "" {
 		opts.IPType = "5_bgp"
 	}
@@ -189,7 +189,7 @@ func (c *client) CreateEIP(opts *ElasticIPOpts) (*eips.PublicIp, error) {
 	return &eip, nil
 }
 
-func (c *client) WaitForEIPActive(eipID string) error {
+func (c *Client) WaitForEIPActive(eipID string) error {
 	return golangsdk.WaitFor(30, func() (bool, error) {
 		status, err := c.GetEIPStatus(eipID)
 		if err != nil {

--- a/services/vpc_test.go
+++ b/services/vpc_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func initNetwork(t *testing.T, client Client) {
+func initNetwork(t *testing.T, client *Client) {
 	require.NoError(t, client.InitVPC())
 }
 


### PR DESCRIPTION
Single-use interface considered to be useless